### PR TITLE
Update DOMConverter.java to use namespace awareness

### DIFF
--- a/src/main/java/org/codehaus/staxmate/dom/DOMConverter.java
+++ b/src/main/java/org/codehaus/staxmate/dom/DOMConverter.java
@@ -111,7 +111,7 @@ public class DOMConverter
         try{
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             dbf.setNamespaceAware(true);
-            db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+            db = dbf.newDocumentBuilder();
         } catch (ParserConfigurationException pce) {
             throw new XMLStreamException(pce);
         }


### PR DESCRIPTION
Method documentation is saying that "Namespace-awareness will be enabled" however the method is instantiating a new DocumentBuilderFactory instead of using the one with NamespaceAware=true